### PR TITLE
Added BreakableObject scripts

### DIFF
--- a/Assets/Scripts/Misc/Breakable.cs
+++ b/Assets/Scripts/Misc/Breakable.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Breakable : MonoBehaviour
+{
+    //Append boulder gameObject to script to get Breaks.cs values.
+    public GameObject boulder;
+    //Call the broken version of the object.
+    [SerializeField] private GameObject broken;
+
+    private void Update() 
+    {
+        //calls the canBreak bool from the Breaks scprit.
+        bool canBreak = boulder.GetComponent<Breaks>().canBreak;
+
+        if(canBreak == true)
+        {
+            SetBroken();
+        }
+    }
+
+    //Call the function when object can be broken.
+    //Replace the current object with the borken version.
+    public void SetBroken()
+    {
+        //spawn broken object on collision.
+        Instantiate(broken, transform.position, Quaternion.identity);
+        broken.SetActive(true);
+        //sets the unbroken object to inactive.
+        gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Misc/Breakable.cs.meta
+++ b/Assets/Scripts/Misc/Breakable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bee91c376411f1c4095c88f01f2cdce7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Misc/Breaks.cs
+++ b/Assets/Scripts/Misc/Breaks.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Breaks : MonoBehaviour
+{
+    //A boolean value to check if the object reached conditions necessary to break other objects.
+    public bool canBreak = false;
+    //A float value to compare the force exerted from the object on the moment of collision.
+    //Set the force treshold to 100 can be altered later.
+    public float forceThresh = 100;
+
+    private void OnCollisionEnter(Collision collision) 
+    {
+        //Gets the impulse value on collision.
+        Vector3 Imp = collision.impulse / Time.fixedDeltaTime;
+        Debug.Log("Impulse = " + Imp.magnitude);
+
+        //If the collided object has a tag breakale check if the amount of force on collision passes to break an object.
+        if(collision.gameObject.tag == "breakable")
+        {
+            //Imp.magnitude is the float vlaue of force exerted by the colliding object.
+            if(Imp.magnitude > forceThresh)
+            {
+                canBreak = true;
+            }       
+        }
+    }
+}

--- a/Assets/Scripts/Misc/Breaks.cs.meta
+++ b/Assets/Scripts/Misc/Breaks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f481025c85207aa4192d434295007176
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added two scripts:
Scripts can be found in Assets->Scripts->Misc

Breaks.cs: appends to an object that breaks another object i.e. the boulder

Breakable.cs: appends to an object being broken. Requires the object that breaks it under the variable: "Boulder" to call values from Break.cs. The "broken" model must be added to the variable: "Broken" so it can be spawned on collision. Both variables can be found in the script inspector.